### PR TITLE
paths

### DIFF
--- a/nbs/bluetopo/build_vrt.py
+++ b/nbs/bluetopo/build_vrt.py
@@ -1,36 +1,39 @@
 import collections
+import copy
 import datetime
-import numpy as np
 import os
+import platform
 import shutil
 import sqlite3
 import sys
-from osgeo import gdal
 
+import numpy as np
+from osgeo import gdal
 
 gdal.UseExceptions()
 gdal.SetConfigOption("COMPRESS_OVERVIEW", "DEFLATE")
 
 
-expected_fields = \
-    dict(value=[int, gdal.GFU_MinMax],
-         count=[int, gdal.GFU_PixelCount],
-         data_assessment=[int, gdal.GFU_Generic],
-         feature_least_depth=[float, gdal.GFU_Generic],
-         significant_features=[float, gdal.GFU_Generic],
-         feature_size=[float, gdal.GFU_Generic],
-         coverage=[int, gdal.GFU_Generic],
-         bathy_coverage=[int, gdal.GFU_Generic],
-         horizontal_uncert_fixed=[float, gdal.GFU_Generic],
-         horizontal_uncert_var=[float, gdal.GFU_Generic],
-         vertical_uncert_fixed=[float, gdal.GFU_Generic],
-         vertical_uncert_var=[float, gdal.GFU_Generic],
-         license_name=[str, gdal.GFU_Generic],
-         license_url=[str, gdal.GFU_Generic],
-         source_survey_id=[str, gdal.GFU_Generic],
-         source_institution=[str, gdal.GFU_Generic],
-         survey_date_start=[str, gdal.GFU_Generic],
-         survey_date_end=[str, gdal.GFU_Generic])
+expected_fields = dict(
+    value=[int, gdal.GFU_MinMax],
+    count=[int, gdal.GFU_PixelCount],
+    data_assessment=[int, gdal.GFU_Generic],
+    feature_least_depth=[float, gdal.GFU_Generic],
+    significant_features=[float, gdal.GFU_Generic],
+    feature_size=[float, gdal.GFU_Generic],
+    coverage=[int, gdal.GFU_Generic],
+    bathy_coverage=[int, gdal.GFU_Generic],
+    horizontal_uncert_fixed=[float, gdal.GFU_Generic],
+    horizontal_uncert_var=[float, gdal.GFU_Generic],
+    vertical_uncert_fixed=[float, gdal.GFU_Generic],
+    vertical_uncert_var=[float, gdal.GFU_Generic],
+    license_name=[str, gdal.GFU_Generic],
+    license_url=[str, gdal.GFU_Generic],
+    source_survey_id=[str, gdal.GFU_Generic],
+    source_institution=[str, gdal.GFU_Generic],
+    survey_date_start=[str, gdal.GFU_Generic],
+    survey_date_end=[str, gdal.GFU_Generic],
+)
 
 
 def connect_to_survey_registry(root: str, target: str) -> sqlite3.Connection:
@@ -55,12 +58,13 @@ def connect_to_survey_registry(root: str, target: str) -> sqlite3.Connection:
         conn = sqlite3.connect(database_path)
         conn.row_factory = sqlite3.Row
     except sqlite3.Error as e:
-        print('Failed to establish SQLite database connection.')
+        print("Failed to establish SQLite database connection.")
         raise e
     if conn is not None:
         try:
             cursor = conn.cursor()
-            cursor.executescript("""CREATE TABLE IF NOT EXISTS tileset (
+            cursor.executescript(
+                """CREATE TABLE IF NOT EXISTS tileset (
                                      tilescheme text PRIMARY KEY,
                                      location text,
                                      downloaded text);
@@ -90,19 +94,18 @@ def connect_to_survey_registry(root: str, target: str) -> sqlite3.Connection:
                                      utm text,
                                      subregion text,
                                      geotiff_disk text,
-                                     rat_disk text);""")
+                                     rat_disk text);"""
+            )
             conn.commit()
         except sqlite3.Error as e:
-            print('Failed to create SQLite tables.')
+            print("Failed to create SQLite tables.")
             raise e
     return conn
 
 
-def build_sub_vrts(subregion: str,
-                   subregion_tiles: list,
-                   root: str,
-                   target: str
-                  ) -> dict:
+def build_sub_vrts(
+    subregion: str, subregion_tiles: list, root: str, target: str, relative_to_vrt: bool
+) -> dict:
     """
     Build the VRTs of a given subregion.
 
@@ -116,6 +119,8 @@ def build_sub_vrts(subregion: str,
         destination directory for project.
     target : str
         the datasource the script will target e.g. 'BlueTopo' or 'Modeling'.
+    relative_to_vrt : bool
+        This arg determines if paths of referenced files inside the VRT are relative or absolute paths.
 
     Returns
     -------
@@ -123,23 +128,26 @@ def build_sub_vrts(subregion: str,
         holds name of subregion and the paths of its VRT and OVR files.
     """
     fields = {
-    "region": subregion["region"],
-    "res_2_vrt": None,
-    "res_2_ovr": None,
-    "res_4_vrt": None,
-    "res_4_ovr": None,
-    "res_8_vrt": None,
-    "res_8_ovr": None,
-    "complete_vrt": None,
-    "complete_ovr": None}
+        "region": subregion["region"],
+        "res_2_vrt": None,
+        "res_2_ovr": None,
+        "res_4_vrt": None,
+        "res_4_ovr": None,
+        "res_8_vrt": None,
+        "res_8_ovr": None,
+        "complete_vrt": None,
+        "complete_ovr": None,
+    }
     rel_dir = os.path.join(f"{target}_VRT", subregion["region"])
     subregion_dir = os.path.join(root, rel_dir)
     try:
         if os.path.isdir(subregion_dir):
             shutil.rmtree(subregion_dir)
     except (OSError, PermissionError) as e:
-        print(f"Failed to remove older vrt files for {subregion['region']}\n"
-               "Please close all files and attempt again")
+        print(
+            f"Failed to remove older vrt files for {subregion['region']}\n"
+            "Please close all files and attempt again"
+        )
         sys.exit(1)
     if not os.path.exists(subregion_dir):
         os.makedirs(subregion_dir)
@@ -154,19 +162,19 @@ def build_sub_vrts(subregion: str,
         tiffs = [os.path.join(root, tile["geotiff_disk"]) for tile in tiles]
         # revisit levels
         if "2" in res:
-            build_vrt(tiffs, res_vrt, [2,4])
+            build_vrt(tiffs, res_vrt, [2, 4], relative_to_vrt)
             vrt_list.append(res_vrt)
             fields["res_2_vrt"] = rel_path
             if os.path.isfile(os.path.join(root, fields["res_2_vrt"] + ".ovr")):
                 fields["res_2_ovr"] = rel_path + ".ovr"
         if "4" in res:
-            build_vrt(tiffs, res_vrt, [4,8])
+            build_vrt(tiffs, res_vrt, [4, 8], relative_to_vrt)
             vrt_list.append(res_vrt)
             fields["res_4_vrt"] = rel_path
             if os.path.isfile(os.path.join(root, fields["res_4_vrt"] + ".ovr")):
                 fields["res_4_ovr"] = rel_path + ".ovr"
         if "8" in res:
-            build_vrt(tiffs, res_vrt, [8])
+            build_vrt(tiffs, res_vrt, [8], relative_to_vrt)
             vrt_list.append(res_vrt)
             fields["res_8_vrt"] = rel_path
             if os.path.isfile(os.path.join(root, fields["res_8_vrt"] + ".ovr")):
@@ -175,14 +183,14 @@ def build_sub_vrts(subregion: str,
             vrt_list.extend(tiffs)
     rel_path = os.path.join(rel_dir, subregion["region"] + "_complete.vrt")
     complete_vrt = os.path.join(root, rel_path)
-    build_vrt(vrt_list, complete_vrt, [16])
+    build_vrt(vrt_list, complete_vrt, [16], relative_to_vrt)
     fields["complete_vrt"] = rel_path
     if os.path.isfile(os.path.join(root, fields["complete_vrt"] + ".ovr")):
         fields["complete_ovr"] = rel_path + ".ovr"
     return fields
 
 
-def build_vrt(files: list, vrt_path: str, levels: list) -> None:
+def build_vrt(files: list, vrt_path: str, levels: list, relative_to_vrt: bool) -> None:
     """
     Build VRT from files.
 
@@ -194,38 +202,50 @@ def build_vrt(files: list, vrt_path: str, levels: list) -> None:
         output vrt path.
     levels
         list of overview levels to be built with the vrt.
+    relative_to_vrt : bool
+        This arg determines if paths of referenced files inside the VRT are relative or absolute paths.
     """
+    # not efficient but insignificant
+    files = copy.deepcopy(files)
     try:
         if os.path.isfile(vrt_path):
             os.remove(vrt_path)
         if os.path.isfile(vrt_path + ".ovr"):
             os.remove(vrt_path + ".ovr")
     except (OSError, PermissionError) as e:
-        print(f"Failed to remove older vrt files for {vrt_path}\n"
-               "Please close all files and attempt again")
+        print(
+            f"Failed to remove older vrt files for {vrt_path}\n"
+            "Please close all files and attempt again"
+        )
         sys.exit(1)
-    vrt_options = gdal.BuildVRTOptions(srcNodata=np.nan,
-                                       VRTNodata=np.nan,
-                                       resampleAlg="near",
-                                       resolution="highest")
-    vrt = gdal.BuildVRT(vrt_path, files, options=vrt_options)
-    band1 = vrt.GetRasterBand(1)
-    band1.SetDescription("Elevation")
-    band2 = vrt.GetRasterBand(2)
-    band2.SetDescription("Uncertainty")
-    band3 = vrt.GetRasterBand(3)
-    band3.SetDescription("Contributor")
-    vrt = None
+    vrt_options = gdal.BuildVRTOptions(
+        srcNodata=np.nan, VRTNodata=np.nan, resampleAlg="near", resolution="highest"
+    )
+    cwd = os.getcwd()
+    try:
+        os.chdir(os.path.dirname(vrt_path))
+        if relative_to_vrt is True:
+            for idx in range(len(files)):
+                files[idx] = os.path.relpath(files[idx], os.path.dirname(vrt_path))
+        relative_vrt_path = os.path.relpath(vrt_path, os.getcwd())
+        vrt = gdal.BuildVRT(relative_vrt_path, files, options=vrt_options)
+        band1 = vrt.GetRasterBand(1)
+        band1.SetDescription("Elevation")
+        band2 = vrt.GetRasterBand(2)
+        band2.SetDescription("Uncertainty")
+        band3 = vrt.GetRasterBand(3)
+        band3.SetDescription("Contributor")
+        vrt = None
+    except:
+        raise RuntimeError(f"VRT failed to build for {vrt_path}")
+    finally:
+        os.chdir(cwd)
     vrt = gdal.Open(vrt_path, 0)
     vrt.BuildOverviews("NEAREST", levels)
     vrt = None
 
 
-def add_vrt_rat(conn: sqlite3.Connection,
-                utm: str,
-                root: str,
-                vrt_path: str
-               ) -> None:
+def add_vrt_rat(conn: sqlite3.Connection, utm: str, root: str, vrt_path: str) -> None:
     """
     Create a raster attribute table for the VRT.
 
@@ -288,8 +308,9 @@ def add_vrt_rat(conn: sqlite3.Connection,
         elif field_type == float:
             col_type = gdal.GFT_Real
         else:
-            raise TypeError("Unknown data type submitted for "
-                            "gdal raster attribute table.")
+            raise TypeError(
+                "Unknown data type submitted for gdal raster attribute table."
+            )
         rat.CreateColumn(entry, col_type, usage)
     rat.SetRowCount(len(surveys))
     for row_idx, survey in enumerate(surveys):
@@ -306,10 +327,9 @@ def add_vrt_rat(conn: sqlite3.Connection,
     contributor_band.SetDefaultRAT(rat)
 
 
-def select_tiles_by_subregion(root: str,
-                              conn: sqlite3.Connection,
-                              subregion: str
-                             ) -> list:
+def select_tiles_by_subregion(
+    root: str, conn: sqlite3.Connection, subregion: str
+) -> list:
     """
     Retrieve all tile records with files in the given subregion.
 
@@ -330,22 +350,25 @@ def select_tiles_by_subregion(root: str,
     cursor = conn.cursor()
     cursor.execute("SELECT * FROM tiles WHERE subregion = ?", (subregion,))
     tiles = [dict(row) for row in cursor.fetchall()]
-    existing_tiles = [tile for tile in tiles
-                      if tile["geotiff_disk"] and tile["rat_disk"]
-                      and os.path.isfile(os.path.join(root, tile["geotiff_disk"]))
-                      and os.path.isfile(os.path.join(root, tile["rat_disk"]))]
+    existing_tiles = [
+        tile
+        for tile in tiles
+        if tile["geotiff_disk"]
+        and tile["rat_disk"]
+        and os.path.isfile(os.path.join(root, tile["geotiff_disk"]))
+        and os.path.isfile(os.path.join(root, tile["rat_disk"]))
+    ]
     if len(tiles) - len(existing_tiles) != 0:
-        print(f"Did not find the files for {len(tiles) - len(existing_tiles)} "
-              f"registered tile(s) in subregion {subregion}. "
-               "Run fetch_tiles to retrieve files "
-               "or correct the directory path if incorrect.")
+        print(
+            f"Did not find the files for {len(tiles) - len(existing_tiles)} "
+            f"registered tile(s) in subregion {subregion}. "
+            "Run fetch_tiles to retrieve files "
+            "or correct the directory path if incorrect."
+        )
     return existing_tiles
 
 
-def select_subregions_by_utm(root: str,
-                             conn: sqlite3.Connection,
-                             utm: str
-                            ) -> list:
+def select_subregions_by_utm(root: str, conn: sqlite3.Connection, utm: str) -> list:
     """
     Retrieve all subregion records with files in the given UTM.
 
@@ -364,23 +387,49 @@ def select_subregions_by_utm(root: str,
         list of subregion records in UTM zone.
     """
     cursor = conn.cursor()
-    cursor.execute("""SELECT * FROM vrt_subregion
-                      WHERE utm = ? AND built = 1""",
-                    (utm,))
+    cursor.execute(
+        """
+        SELECT * FROM vrt_subregion
+        WHERE utm = ? AND built = 1
+        """,
+        (utm,),
+    )
     subregions = [dict(row) for row in cursor.fetchall()]
     for s in subregions:
         if (
-        (s["res_2_vrt"] and not os.path.isfile(os.path.join(root, s["res_2_vrt"]))) or
-        (s["res_2_ovr"] and not os.path.isfile(os.path.join(root, s["res_2_ovr"]))) or
-        (s["res_4_vrt"] and not os.path.isfile(os.path.join(root, s["res_4_vrt"]))) or
-        (s["res_4_ovr"] and not os.path.isfile(os.path.join(root, s["res_4_ovr"]))) or
-        (s["res_8_vrt"] and not os.path.isfile(os.path.join(root, s["res_8_vrt"]))) or
-        (s["res_8_ovr"] and not os.path.isfile(os.path.join(root, s["res_8_ovr"]))) or
-        (s["complete_vrt"] is None or not os.path.isfile(os.path.join(root, s["complete_vrt"]))) or
-        (s["complete_ovr"] is None or not os.path.isfile(os.path.join(root, s["complete_ovr"])))
+            (s["res_2_vrt"] and not os.path.isfile(os.path.join(root, s["res_2_vrt"])))
+            or (
+                s["res_2_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_2_ovr"]))
+            )
+            or (
+                s["res_4_vrt"]
+                and not os.path.isfile(os.path.join(root, s["res_4_vrt"]))
+            )
+            or (
+                s["res_4_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_4_ovr"]))
+            )
+            or (
+                s["res_8_vrt"]
+                and not os.path.isfile(os.path.join(root, s["res_8_vrt"]))
+            )
+            or (
+                s["res_8_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_8_ovr"]))
+            )
+            or (
+                s["complete_vrt"] is None
+                or not os.path.isfile(os.path.join(root, s["complete_vrt"]))
+            )
+            or (
+                s["complete_ovr"] is None
+                or not os.path.isfile(os.path.join(root, s["complete_ovr"]))
+            )
         ):
-            raise RuntimeError(f"Subregion VRT files missing for {s['utm']}. "
-                                "Please rerun.")
+            raise RuntimeError(
+                f"Subregion VRT files missing for {s['utm']}. Please rerun."
+            )
     return subregions
 
 
@@ -437,16 +486,24 @@ def update_subregion(conn: sqlite3.Connection, fields: dict) -> None:
         VRT and OVR files.
     """
     cursor = conn.cursor()
-    cursor.execute("""UPDATE vrt_subregion
+    cursor.execute(
+        """UPDATE vrt_subregion
                       SET res_2_vrt = ?, res_2_ovr = ?, res_4_vrt = ?,
                       res_4_ovr = ?, res_8_vrt = ?, res_8_ovr = ?,
                       complete_vrt = ?, complete_ovr = ?, built = 1
                       WHERE region = ?""",
-                     (fields["res_2_vrt"], fields["res_2_ovr"],
-                      fields["res_4_vrt"], fields["res_4_ovr"],
-                      fields["res_8_vrt"], fields["res_8_ovr"],
-                      fields["complete_vrt"], fields["complete_ovr"],
-                      fields["region"]))
+        (
+            fields["res_2_vrt"],
+            fields["res_2_ovr"],
+            fields["res_4_vrt"],
+            fields["res_4_ovr"],
+            fields["res_8_vrt"],
+            fields["res_8_ovr"],
+            fields["complete_vrt"],
+            fields["complete_ovr"],
+            fields["region"],
+        ),
+    )
     conn.commit()
 
 
@@ -463,10 +520,16 @@ def update_utm(conn: sqlite3.Connection, fields: dict) -> None:
         VRT and OVR files.
     """
     cursor = conn.cursor()
-    cursor.execute("""UPDATE vrt_utm
+    cursor.execute(
+        """UPDATE vrt_utm
                       SET utm_vrt = ?, utm_ovr = ?, built = 1
                       WHERE utm = ?""",
-                   (fields["utm_vrt"], fields["utm_ovr"], fields["utm"],))
+        (
+            fields["utm_vrt"],
+            fields["utm_ovr"],
+            fields["utm"],
+        ),
+    )
     conn.commit()
 
 
@@ -494,27 +557,65 @@ def missing_subregions(root: str, conn: sqlite3.Connection) -> int:
     # todo comparison against tiles table to know res vrts exist where expected
     for s in subregions:
         if (
-        (s["res_2_vrt"] and not os.path.isfile(os.path.join(root, s["res_2_vrt"]))) or
-        (s["res_2_ovr"] and not os.path.isfile(os.path.join(root, s["res_2_ovr"]))) or
-        (s["res_4_vrt"] and not os.path.isfile(os.path.join(root, s["res_4_vrt"]))) or
-        (s["res_4_ovr"] and not os.path.isfile(os.path.join(root, s["res_4_ovr"]))) or
-        (s["res_8_vrt"] and not os.path.isfile(os.path.join(root, s["res_8_vrt"]))) or
-        (s["res_8_ovr"] and not os.path.isfile(os.path.join(root, s["res_8_ovr"]))) or
-        (s["complete_vrt"] is None or not os.path.isfile(os.path.join(root, s["complete_vrt"]))) or
-        (s["complete_ovr"] is None or not os.path.isfile(os.path.join(root, s["complete_ovr"])))
+            (s["res_2_vrt"] and not os.path.isfile(os.path.join(root, s["res_2_vrt"])))
+            or (
+                s["res_2_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_2_ovr"]))
+            )
+            or (
+                s["res_4_vrt"]
+                and not os.path.isfile(os.path.join(root, s["res_4_vrt"]))
+            )
+            or (
+                s["res_4_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_4_ovr"]))
+            )
+            or (
+                s["res_8_vrt"]
+                and not os.path.isfile(os.path.join(root, s["res_8_vrt"]))
+            )
+            or (
+                s["res_8_ovr"]
+                and not os.path.isfile(os.path.join(root, s["res_8_ovr"]))
+            )
+            or (
+                s["complete_vrt"] is None
+                or not os.path.isfile(os.path.join(root, s["complete_vrt"]))
+            )
+            or (
+                s["complete_ovr"] is None
+                or not os.path.isfile(os.path.join(root, s["complete_ovr"]))
+            )
         ):
             missing_subregion_count += 1
-            cursor.execute("""UPDATE vrt_subregion
+            cursor.execute(
+                """UPDATE vrt_subregion
                            SET res_2_vrt = ?, res_2_ovr = ?, res_4_vrt = ?,
                            res_4_ovr = ?, res_8_vrt = ?, res_8_ovr = ?,
                            complete_vrt = ?, complete_ovr = ?, built = 0
                            WHERE region = ?""",
-                           (None, None, None, None, None, None, None, None,
-                           s["region"],))
-            cursor.execute("""UPDATE vrt_utm
+                (
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    s["region"],
+                ),
+            )
+            cursor.execute(
+                """UPDATE vrt_utm
                               SET utm_vrt = ?, utm_ovr = ?, built = 0
                               WHERE utm = ?""",
-                           (None, None, s["utm"],))
+                (
+                    None,
+                    None,
+                    s["utm"],
+                ),
+            )
             conn.commit()
     return missing_subregion_count
 
@@ -541,19 +642,28 @@ def missing_utms(root: str, conn: sqlite3.Connection) -> int:
     utms = [dict(row) for row in cursor.fetchall()]
     missing_utm_count = 0
     for utm in utms:
-        if (utm["utm_vrt"] is None or utm["utm_ovr"] is None
-        or os.path.isfile(os.path.join(root, utm["utm_vrt"])) == False
-        or os.path.isfile(os.path.join(root, utm["utm_ovr"])) == False):
+        if (
+            utm["utm_vrt"] is None
+            or utm["utm_ovr"] is None
+            or os.path.isfile(os.path.join(root, utm["utm_vrt"])) == False
+            or os.path.isfile(os.path.join(root, utm["utm_ovr"])) == False
+        ):
             missing_utm_count += 1
-            cursor.execute("""UPDATE vrt_utm
+            cursor.execute(
+                """UPDATE vrt_utm
                               SET utm_vrt = ?, utm_ovr = ?, built = 0
                               WHERE utm = ?""",
-                           (None, None, utm["utm"],))
+                (
+                    None,
+                    None,
+                    utm["utm"],
+                ),
+            )
             conn.commit()
     return missing_utm_count
 
 
-def main(root:str, target: str = None) -> None:
+def main(root: str, target: str = None, relative_to_vrt: bool = True) -> None:
     """
     Build a gdal VRT for all available tiles.
     This VRT is a collection of smaller areas described as VRTs.
@@ -565,18 +675,30 @@ def main(root:str, target: str = None) -> None:
     Parameters
     ----------
     root
-        The directory path to use. Will create if it does not currently exist. 
+        The directory path to use. Will create if it does not currently exist.
         Required argument.
     target : str
-        The NBS offers various products to different end-users. Some are available publicly. 
+        The NBS offers various products to different end-users. Some are available publicly.
         Use this argument to identify which product you want to target. BlueTopo is the default.
+    relative_to_vrt : bool
+        Use this argument to set paths of referenced files inside the VRT as relative or absolute paths.
+
     """
+    root = os.path.expanduser(root)
+    if os.path.isabs(root) is False:
+        print("Please use an absolute path for your project folder.")
+        if "windows" not in platform.system().lower():
+            print("Typically for non windows systems this means starting with '/'")
+        sys.exit(1)
+
     if int(gdal.VersionInfo()) < 3040000:
-        raise RuntimeError("Please update GDAL to >=3.4 to run build_vrt. \n"
-                         "Some users have encountered issues with "
-                         "conda's installation of GDAL 3.4. "
-                         "Try more recent versions of GDAL if you also "
-                         "encounter issues in your conda environment.")
+        raise RuntimeError(
+            "Please update GDAL to >=3.4 to run build_vrt. \n"
+            "Some users have encountered issues with "
+            "conda's installation of GDAL 3.4. "
+            "Try more recent versions of GDAL if you also "
+            "encounter issues in your conda environment."
+        )
 
     if target is None or target.lower() == "bluetopo":
         target = "BlueTopo"
@@ -588,75 +710,89 @@ def main(root:str, target: str = None) -> None:
         raise ValueError(f"Invalid target data: {target}")
 
     if not os.path.isdir(root):
-        raise ValueError("Entered folder path not found")
+        raise ValueError(f"Folder path not found: {root}")
 
     if not os.path.isfile(os.path.join(root, f"{target.lower()}_registry.db")):
-        raise ValueError(f"SQLite database not found. Confirm correct folder. "
-                          "Note: fetch_tiles must be run at least once prior "
-                          "to build_vrt")
+        raise ValueError(
+            f"SQLite database not found. Confirm correct folder. "
+            "Note: fetch_tiles must be run at least once prior "
+            "to build_vrt"
+        )
 
     start = datetime.datetime.now()
-    print(f"{target}: Beginning work on {root}")
+    print(f"{target}: Beginning work in path: {root}")
     conn = connect_to_survey_registry(root, target)
 
     # subregions missing files
     missing_subregion_count = missing_subregions(root, conn)
     if missing_subregion_count:
-        print(f"{missing_subregion_count} subregion vrts files missing. "
-               "Added to build list.")
+        print(
+            f"{missing_subregion_count} subregion vrts files missing. "
+            "Added to build list."
+        )
 
     # build subregion vrts
     unbuilt_subregions = select_unbuilt_subregions(conn)
     if len(unbuilt_subregions) > 0:
-        print(f"Building {len(unbuilt_subregions)} subregion vrt(s). This may "
-               "take minutes or hours depending on the amount of tiles.")
+        print(
+            f"Building {len(unbuilt_subregions)} subregion vrt(s). This may "
+            "take minutes or hours depending on the amount of tiles."
+        )
         for ub_sr in unbuilt_subregions:
-            sr_tiles = select_tiles_by_subregion(root, conn, ub_sr['region'])
+            sr_tiles = select_tiles_by_subregion(root, conn, ub_sr["region"])
             if len(sr_tiles) < 1:
                 continue
-            fields = build_sub_vrts(ub_sr, sr_tiles, root, target)
+            fields = build_sub_vrts(ub_sr, sr_tiles, root, target, relative_to_vrt)
             update_subregion(conn, fields)
     else:
-        print("Subregion vrt(s) appear up to date with the most recently "
-              "fetched tiles.")
+        print(
+            "Subregion vrt(s) appear up to date with the most recently "
+            "fetched tiles."
+        )
 
     # utms missing files
     missing_utm_count = missing_utms(root, conn)
     if missing_utm_count:
-        print(f"{missing_utm_count} utm vrts files missing. "
-               "Added to build list.")
+        print(f"{missing_utm_count} utm vrts files missing. Added to build list.")
 
     # build utm vrts
     unbuilt_utms = select_unbuilt_utms(conn)
     if len(unbuilt_utms) > 0:
-        print(f"Building {len(unbuilt_utms)} utm vrt(s). This may take minutes "
-               "or hours depending on the amount of tiles.")
+        print(
+            f"Building {len(unbuilt_utms)} utm vrt(s). This may take minutes "
+            "or hours depending on the amount of tiles."
+        )
         for ub_utm in unbuilt_utms:
-            subregions = select_subregions_by_utm(root, conn, ub_utm['utm'])
-            vrt_list = [os.path.join(root, subregion['complete_vrt'])
-                        for subregion in subregions]
+            subregions = select_subregions_by_utm(root, conn, ub_utm["utm"])
+            vrt_list = [
+                os.path.join(root, subregion["complete_vrt"])
+                for subregion in subregions
+            ]
             if len(vrt_list) < 1:
                 continue
-            rel_path = os.path.join(f"{target}_VRT",
-                                    f"{target}_Fetched_UTM{ub_utm['utm']}.vrt")
+            rel_path = os.path.join(
+                f"{target}_VRT", f"{target}_Fetched_UTM{ub_utm['utm']}.vrt"
+            )
             utm_vrt = os.path.join(root, rel_path)
             print(f"Building utm{ub_utm['utm']}...")
-            build_vrt(vrt_list, utm_vrt, [32,64])
-            add_vrt_rat(conn, ub_utm['utm'], root, utm_vrt)
-            fields = {'utm_vrt': rel_path,
-                      'utm_ovr': None,
-                      'utm': ub_utm['utm']}
-            if os.path.isfile(os.path.join(root, rel_path + '.ovr')):
-                fields['utm_ovr'] = rel_path + '.ovr'
+            build_vrt(vrt_list, utm_vrt, [32, 64], relative_to_vrt)
+            add_vrt_rat(conn, ub_utm["utm"], root, utm_vrt)
+            fields = {"utm_vrt": rel_path, "utm_ovr": None, "utm": ub_utm["utm"]}
+            if os.path.isfile(os.path.join(root, rel_path + ".ovr")):
+                fields["utm_ovr"] = rel_path + ".ovr"
             else:
-                raise RuntimeError("Overview failed to create for "
-                                  f"utm{ub_utm['utm']}. Please try again. "
-                                   "If error persists, please contact NBS.")
+                raise RuntimeError(
+                    "Overview failed to create for "
+                    f"utm{ub_utm['utm']}. Please try again. "
+                    "If error persists, please contact NBS."
+                )
             update_utm(conn, fields)
     else:
-        print("UTM vrt(s) appear up to date with the most recently "
-             f"fetched tiles.\nNote: deleting the {target}_VRT folder will "
-              "allow you to recreate from scratch if necessary")
+        print(
+            "UTM vrt(s) appear up to date with the most recently "
+            f"fetched tiles.\nNote: deleting the {target}_VRT folder will "
+            "allow you to recreate from scratch if necessary"
+        )
 
     total_time = datetime.datetime.now() - start
     print(f"Operation complete. Elapsed time: {total_time}")

--- a/nbs/bluetopo/cli.py
+++ b/nbs/bluetopo/cli.py
@@ -1,70 +1,133 @@
+import argparse
 from argparse import ArgumentParser
+
 from nbs.bluetopo.build_vrt import main as vrt
 from nbs.bluetopo.fetch_tiles import main as fetch
 
 
+def str_to_bool(relative_to_vrt):
+    if isinstance(relative_to_vrt, bool):
+        return relative_to_vrt
+    if relative_to_vrt.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif relative_to_vrt.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
 def build_vrt_command():
     """
-    console_scripts entry point for build_vrt cli command 
+    console_scripts entry point for build_vrt cli command
 
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', '--dir', '--directory', 
-                        help='The directory path to use. ' 
-                        'Will create if it does not currently exist. Required argument.', 
-                        type=str, 
-                        nargs='?',
-                        dest ='dir',
-                        required=True)
-    parser.add_argument('-t', '--targ', '--target', 
-                        help=('The NBS offers various products to different end-users. '
-                        'Some are available publicly. Use this argument to identify '
-                        'which product you want to target. BlueTopo is the default.'), 
-                        type=str.lower, 
-                        choices=["bluetopo", "modeling"], 
-                        default='bluetopo',
-                        dest='target',
-                        nargs='?')
+    parser.add_argument(
+        "-d",
+        "--dir",
+        "--directory",
+        help="The directory path to use. "
+        "Will create if it does not currently exist. Required argument.",
+        type=str,
+        nargs="?",
+        dest="dir",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--targ",
+        "--target",
+        help=(
+            "The NBS offers various products to different end-users. "
+            "Some are available publicly. Use this argument to identify "
+            "which product you want to target. BlueTopo is the default."
+        ),
+        type=str.lower,
+        choices=["bluetopo", "modeling"],
+        default="bluetopo",
+        dest="target",
+        nargs="?",
+    )
+    parser.add_argument(
+        "-r",
+        "--rel",
+        "--relative_to_vrt",
+        help=(
+            "This bool argument will determine whether files referenced in the VRT "
+            "are relative or absolute. The default value is true setting all paths "
+            "inside the VRT to relative."
+        ),
+        nargs="?",
+        dest="relative_to_vrt",
+        default="true",
+        const=True,
+        type=str_to_bool,
+    )
     args = parser.parse_args()
-    vrt(root = args.dir, target = args.target)
+    vrt(root=args.dir, target=args.target, relative_to_vrt=args.relative_to_vrt)
 
 
 def fetch_tiles_command():
     """
-    console_scripts entry point for fetch_tiles cli command 
+    console_scripts entry point for fetch_tiles cli command
 
     """
     parser = ArgumentParser()
-    parser.add_argument('-d', '--dir', '--directory', 
-                        help='The directory path to use. ' 
-                        'Will create if it does not currently exist. Required argument.', 
-                        type=str, 
-                        nargs='?',
-                        dest='dir',
-                        required=True)
-    parser.add_argument('-g', '--geom', '--geometry', 
-                        help=('The geometry file to use to find intersecting available tiles. '
-                        'The returned tile ids at the time of intersection will be added to '
-                        'tracking. fetch_tiles will stay up to date with the latest data '
-                        'available from the NBS for all tracked tiles. This argument is '
-                        'not necessary if you do not want to add new tile ids to tracking.'), 
-                        type=str, 
-                        dest='geom',
-                        nargs='?')
-    parser.add_argument('-t', '--targ', '--target', 
-                        help=('The NBS offers various products to different end-users. '
-                        'Some are available publicly. Use this argument to identify '
-                        'which product you want to target. BlueTopo is the default.'), 
-                        type=str.lower, 
-                        choices=["bluetopo", "modeling"], 
-                        default='bluetopo', 
-                        dest='target',
-                        nargs='?')
-    parser.add_argument('-u', '--untrack', 
-                        help=('This flag will untrack tiles that have missing files in your local '
-                        'download directory. fetch_tiles will no longer retrieve these tiles.'), 
-                        dest='untrack',
-                        action="store_true")
+    parser.add_argument(
+        "-d",
+        "--dir",
+        "--directory",
+        help="The directory path to use. "
+        "Will create if it does not currently exist. Required argument.",
+        type=str,
+        nargs="?",
+        dest="dir",
+        required=True,
+    )
+    parser.add_argument(
+        "-g",
+        "--geom",
+        "--geometry",
+        help=(
+            "The geometry file to use to find intersecting available tiles. "
+            "The returned tile ids at the time of intersection will be added to "
+            "tracking. fetch_tiles will stay up to date with the latest data "
+            "available from the NBS for all tracked tiles. This argument is "
+            "not necessary if you do not want to add new tile ids to tracking."
+        ),
+        type=str,
+        dest="geom",
+        nargs="?",
+    )
+    parser.add_argument(
+        "-t",
+        "--targ",
+        "--target",
+        help=(
+            "The NBS offers various products to different end-users. "
+            "Some are available publicly. Use this argument to identify "
+            "which product you want to target. BlueTopo is the default."
+        ),
+        type=str.lower,
+        choices=["bluetopo", "modeling"],
+        default="bluetopo",
+        dest="target",
+        nargs="?",
+    )
+    parser.add_argument(
+        "-u",
+        "--untrack",
+        help=(
+            "This flag will untrack tiles that have missing files in your local "
+            "download directory. fetch_tiles will no longer retrieve these tiles."
+        ),
+        dest="untrack",
+        action="store_true",
+    )
     args = parser.parse_args()
-    fetch(root = args.dir, desired_area_filename = args.geom, 
-         untrack_missing = args.untrack, target = args.target)
+    fetch(
+        root=args.dir,
+        desired_area_filename=args.geom,
+        untrack_missing=args.untrack,
+        target=args.target,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BlueTopo"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
-    {name = "Glen Rice", email = "ocs.nbs@noaa.gov"},
-    {name = "Tashi Geleg", email = "ocs.nbs@noaa.gov"},
+  { name = "Glen Rice", email = "ocs.nbs@noaa.gov" },
+  { name = "Tashi Geleg", email = "ocs.nbs@noaa.gov" },
 ]
 description = "National Bathymetric Source Project BlueTopo"
 readme = "README.md"
-license = {file ="LICENSE"}
+license = { file = "LICENSE" }
 keywords = ["BlueTopo", "National Bathymetric Source", "Bathymetry"]
-dependencies = [
-    "numpy",
-    "boto3",
-]
+dependencies = ["numpy", "boto3"]
 
 [project.scripts]
 fetch_tiles = "nbs.bluetopo.cli:fetch_tiles_command"
@@ -25,3 +22,4 @@ build_vrt = "nbs.bluetopo.cli:build_vrt_command"
 [project.urls]
 homepage = "https://www.nauticalcharts.noaa.gov/data/bluetopo.html"
 source = "https://github.com/noaa-ocs-hydrography/BlueTopo"
+


### PR DESCRIPTION
Changes

- Requires absolute paths for entered in arguments. This only deals with the project folder and geometry path. This can be changed in the future to allow both absolute and relative arguments after a little more thought in the implementation. Would rather get this fix in now in the meantime. In addition, we will now expand the entered paths so keys like ~ can be used.

- As a separate thing, paths inside the VRT file can now be relative or absolute. By default they will be relative. Using a new relative_to_vrt arg, which defaults to true, you can set the value to false for the references inside the VRT file to be absolute instead.

Related to issue #17 