### PR TITLE
Empty tiles and different keywords error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install conda (If you have not already): [conda installation](https://docs.conda
 In the command line, create an environment with the required packages:
 
 ```
-conda create -n bluetopo_env -c conda-forge 'gdal>=3.4'
+conda create -n bluetopo_env -c conda-forge 'gdal>=3.4,<3.11'
 ```
 
 ```

--- a/nbs/bluetopo/core/fetch_tiles.py
+++ b/nbs/bluetopo/core/fetch_tiles.py
@@ -538,24 +538,28 @@ def download_tiles(
                     "subregion": fields["subregion"],
                     "utm": fields["utm"],
                 }
-                for object_name in objs["Contents"]:
-                    source_name = object_name["Key"]
-                    relative = os.path.join(data_source, f"UTM{fields['utm']}", os.path.basename(source_name))
-                    destination_name = os.path.join(project_dir, relative)
-                    if not os.path.exists(os.path.dirname(destination_name)):
-                        os.makedirs(os.path.dirname(destination_name))
-                    if ".aux" in source_name.lower():
-                        download_dict[tilename]["rat"] = source_name
-                        download_dict[tilename]["rat_dest"] = destination_name
-                        download_dict[tilename]["rat_verified"] = fields["rat_verified"]
-                        download_dict[tilename]["rat_disk"] = relative
-                        download_dict[tilename]["rat_sha256_checksum"] = fields["rat_sha256_checksum"]
-                    else:
-                        download_dict[tilename]["geotiff"] = source_name
-                        download_dict[tilename]["geotiff_dest"] = destination_name
-                        download_dict[tilename]["geotiff_verified"] = fields["geotiff_verified"]
-                        download_dict[tilename]["geotiff_disk"] = relative
-                        download_dict[tilename]["geotiff_sha256_checksum"] = fields["geotiff_sha256_checksum"]
+                try:
+                    for object_name in objs["Contents"]:
+                        source_name = object_name["Key"]
+                        relative = os.path.join(data_source, f"UTM{fields['utm']}", os.path.basename(source_name))
+                        destination_name = os.path.join(project_dir, relative)
+                        if not os.path.exists(os.path.dirname(destination_name)):
+                            os.makedirs(os.path.dirname(destination_name))
+                        if ".aux" in source_name.lower():
+                            download_dict[tilename]["rat"] = source_name
+                            download_dict[tilename]["rat_dest"] = destination_name
+                            download_dict[tilename]["rat_verified"] = fields["rat_verified"]
+                            download_dict[tilename]["rat_disk"] = relative
+                            download_dict[tilename]["rat_sha256_checksum"] = fields["rat_sha256_checksum"]
+                        else:
+                            download_dict[tilename]["geotiff"] = source_name
+                            download_dict[tilename]["geotiff_dest"] = destination_name
+                            download_dict[tilename]["geotiff_verified"] = fields["geotiff_verified"]
+                            download_dict[tilename]["geotiff_disk"] = relative
+                            download_dict[tilename]["geotiff_sha256_checksum"] = fields["geotiff_sha256_checksum"]
+                except KeyError:
+                    missing_tiles.append(tilename)
+                    continue
                 tiles_found.append(tilename)
             else:
                 tiles_not_found.append(tilename)
@@ -1092,7 +1096,7 @@ def insert_new(conn: sqlite3.Connection, tiles: list) -> int:
         amount of delivered tiles from input tiles.
     """
     cursor = conn.cursor()
-    tile_list = [(tile["tile"],) for tile in tiles if tile["Delivered_Date"] and tile["GeoTIFF_Link"] and tile["RAT_Link"]]
+    tile_list = [(tile["input_tile"],) for tile in tiles if tile["Delivered_Date"] and tile["GeoTIFF_Link"] and tile["method_RAT_Link"]]
     cursor.executemany(
         """INSERT INTO tiles(tilename)
                           VALUES(?) ON CONFLICT DO NOTHING""",


### PR DESCRIPTION
When trying to use the package a coworker and I found that it was erroring trying to get the RAT_link, and that there were some tiles that returned empty objects from S3.

I’m not sure this will work more generally, but here is what we patched around. 

We also found that GDAL now needs to be limited to less than 3.11.

```py
❯ pixi run fetch_tiles -d /Users/akerney/GMRI/RES/claire-bluetopo/ -g /Users/akerney/GMRI/RES/claire-bluetopo/coastal_me_ao
i.shp
[2025-11-17 12:04:14 EST] BlueTopo: Beginning work in project folder: /Users/akerney/GMRI/RES/claire-bluetopo/
[2025-11-17 12:04:16 EST] BlueTopo: Downloaded BlueTopo_Tile_Scheme_20251117_095548.gpkg
Traceback (most recent call last):
  File "/Users/akerney/GMRI/RES/claire-bluetopo/.pixi/envs/default/bin/fetch_tiles", line 10, in <module>
    sys.exit(fetch_tiles_command())
             ~~~~~~~~~~~~~~~~~~~^^
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/cli/cli.py", line 103, in fetch_tiles_command
    fetch_tiles(
    ~~~~~~~~~~~^
        project_dir=args.dir,
        ^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        data_source=args.source,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/core/fetch_tiles.py", line 1659, in main
    available_tile_count = insert_new(conn, tile_list)
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/core/fetch_tiles.py", line 1095, in insert_new
    tile_list = [(tile["tile"],) for tile in tiles if tile["Delivered_Date"] and tile["GeoTIFF_Link"] and tile["RAT_Link"]]
                                                                                                          ~~~~^^^^^^^^^^^^
KeyError: 'RAT_Link’
```

```py
❯ pixi run fetch_tiles -d /Users/akerney/GMRI/RES/claire-bluetopo/ -g /Users/akerney/GMRI/RES/claire-bluetopo/coastal_me_ao
i.shp
[2025-11-17 12:07:39 EST] BlueTopo: Beginning work in project folder: /Users/akerney/GMRI/RES/claire-bluetopo/
[2025-11-17 12:07:40 EST] BlueTopo: Downloaded BlueTopo_Tile_Scheme_20251117_095548.gpkg

Tracking 925 available BlueTopo tile(s) discovered in a total of 992 intersected tile(s) with given polygon.
Warning: Unexpected removal of delivered date for tile BH54W5HK
Warning: Unexpected removal of delivered date for tile BH54X5HK
Warning: Unexpected removal of delivered date for tile BH54V5HM
Warning: Unexpected removal of delivered date for tile BH4ZZ5GR
Warning: Unexpected removal of delivered date for tile BH5255GW
Warning: Unexpected removal of delivered date for tile BH54V5HK
Warning: Unexpected removal of delivered date for tile BH54V5HN

Resolving fetch list...
Traceback (most recent call last):
  File "/Users/akerney/GMRI/RES/claire-bluetopo/.pixi/envs/default/bin/fetch_tiles", line 10, in <module>
    sys.exit(fetch_tiles_command())
             ~~~~~~~~~~~~~~~~~~~^^
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/cli/cli.py", line 103, in fetch_tiles_command
    fetch_tiles(
    ~~~~~~~~~~~^
        project_dir=args.dir,
        ^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        data_source=args.source,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/core/fetch_tiles.py", line 1688, in main
    ) = download_tiles(conn, project_dir, tile_prefix, data_source)
        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/akerney/GMRI/RES/BlueTopo/nbs/bluetopo/core/fetch_tiles.py", line 541, in download_tiles
    for object_name in objs["Contents"]:
                       ~~~~^^^^^^^^^^^^
KeyError: 'Contents’
```